### PR TITLE
Add settings button and organize reset materials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "death-stranding-materials",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "death-stranding-materials",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "death-stranding-materials",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "death-stranding-materials",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import pkg from '../package.json'
 
 const APP_VERSION = pkg.version
@@ -70,6 +70,27 @@ function App() {
 
   const [materials, setMaterials] = useState<Material[]>(getInitialMaterials)
   const [inputValues, setInputValues] = useState<{ [key: string]: string }>({})
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const settingsRef = useRef<HTMLDivElement>(null)
+
+  // Handle click outside to close settings menu
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (settingsRef.current && !settingsRef.current.contains(event.target as Node)) {
+        setIsSettingsOpen(false)
+      }
+    }
+
+    if (isSettingsOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener('touchstart', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('touchstart', handleClickOutside)
+    }
+  }, [isSettingsOpen])
 
   // Save materials to localStorage whenever they change
   const saveMaterials = (newMaterials: Material[]) => {
@@ -170,6 +191,64 @@ function App() {
   return (
     <div className="min-h-screen bg-ds-dark p-2 sm:p-4">
       <div className="fixed top-1 left-1 text-xs text-slate-400 z-50 pointer-events-none">v{APP_VERSION}</div>
+      
+      {/* Settings Button */}
+      <div className="fixed top-2 right-2 z-50" ref={settingsRef}>
+        <button
+          onClick={() => setIsSettingsOpen(!isSettingsOpen)}
+          className="bg-ds-gray border border-ds-light-gray text-white p-2 sm:p-3 rounded-lg 
+                   hover:bg-ds-light-gray hover:border-ds-blue transition-all duration-200
+                   focus:outline-none focus:ring-2 focus:ring-ds-blue focus:ring-opacity-50
+                   flex items-center justify-center"
+          aria-label="Settings"
+        >
+          <svg
+            className="w-5 h-5 sm:w-6 sm:h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+            />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+
+        {/* Settings Dropdown Menu */}
+        {isSettingsOpen && (
+          <div className="absolute right-0 top-full mt-2 w-48 sm:w-56 bg-ds-gray border border-ds-light-gray rounded-lg shadow-lg py-2 z-50">
+            <button
+              onClick={() => {
+                resetMaterials()
+                setIsSettingsOpen(false)
+              }}
+              className="w-full text-left px-4 py-3 text-white hover:bg-ds-light-gray transition-colors duration-200
+                       flex items-center gap-3 text-sm sm:text-base"
+            >
+              <svg
+                className="w-4 h-4 sm:w-5 sm:h-5 text-ds-red"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+              <span className="text-ds-red">Reset All Materials</span>
+            </button>
+          </div>
+        )}
+      </div>
 
       <div className="max-w-4xl mx-auto flex flex-col gap-4 sm:gap-6">
         {/* Materials Grid */}
@@ -245,18 +324,6 @@ function App() {
               )}
             </div>
           ))}
-        </div>
-
-        {/* Reset Button */}
-        <div className="text-center">
-          <button
-            onClick={resetMaterials}
-            className="bg-ds-red border border-ds-red text-white px-4 py-2 sm:px-6 sm:py-3 rounded-lg 
-                     hover:bg-red-700 hover:border-red-700 transition-all duration-200
-                     focus:outline-none focus:ring-2 focus:ring-ds-red focus:ring-opacity-50 text-sm sm:text-base"
-          >
-            Reset All Materials
-          </button>
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
   // Handle click outside to close settings menu
   useEffect(() => {
     const handleClickOutside = (event: Event) => {
-      if (settingsRef.current && !settingsRef.current.contains(event.target as Node)) {
+      if (settingsRef.current && event.target && !settingsRef.current.contains(event.target as Node)) {
         setIsSettingsOpen(false)
       }
     }
@@ -195,12 +195,15 @@ function App() {
       {/* Settings Button */}
       <div className="fixed top-2 right-2 z-50" ref={settingsRef}>
         <button
+          id="settings-button"
           onClick={() => setIsSettingsOpen(!isSettingsOpen)}
           className="bg-ds-gray border border-ds-light-gray text-white p-2 sm:p-3 rounded-lg 
                    hover:bg-ds-light-gray hover:border-ds-blue transition-all duration-200
                    focus:outline-none focus:ring-2 focus:ring-ds-blue focus:ring-opacity-50
                    flex items-center justify-center"
           aria-label="Settings"
+          aria-expanded={isSettingsOpen}
+          aria-haspopup="menu"
         >
           <svg
             className="w-5 h-5 sm:w-6 sm:h-6"
@@ -221,8 +224,13 @@ function App() {
 
         {/* Settings Dropdown Menu */}
         {isSettingsOpen && (
-          <div className="absolute right-0 top-full mt-2 w-48 sm:w-56 bg-ds-gray border border-ds-light-gray rounded-lg shadow-lg py-2 z-50">
+          <div 
+            role="menu" 
+            aria-labelledby="settings-button"
+            className="absolute right-0 top-full mt-2 w-48 sm:w-56 bg-ds-gray border border-ds-light-gray rounded-lg shadow-lg py-2 z-50"
+          >
             <button
+              role="menuitem"
               onClick={() => {
                 resetMaterials()
                 setIsSettingsOpen(false)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
 
   // Handle click outside to close settings menu
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutside = (event: Event) => {
       if (settingsRef.current && !settingsRef.current.contains(event.target as Node)) {
         setIsSettingsOpen(false)
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
   // Handle click outside to close settings menu
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (settingsRef.current && event.target && event.target instanceof Node && !settingsRef.current.contains(event.target)) {
+      if (settingsRef.current && event.target instanceof Node && !settingsRef.current.contains(event.target)) {
         setIsSettingsOpen(false)
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,8 +75,8 @@ function App() {
 
   // Handle click outside to close settings menu
   useEffect(() => {
-    const handleClickOutside = (event: Event) => {
-      if (settingsRef.current && event.target && !settingsRef.current.contains(event.target as Node)) {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (settingsRef.current && event.target && event.target instanceof Node && !settingsRef.current.contains(event.target)) {
         setIsSettingsOpen(false)
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,15 +76,18 @@ function App() {
   // Handle click outside to close settings menu
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (settingsRef.current && event.target instanceof Node && !settingsRef.current.contains(event.target)) {
+      if (
+        isSettingsOpen &&
+        settingsRef.current &&
+        event.target instanceof Node &&
+        !settingsRef.current.contains(event.target)
+      ) {
         setIsSettingsOpen(false)
       }
     }
 
-    if (isSettingsOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      document.addEventListener('touchstart', handleClickOutside)
-    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('touchstart', handleClickOutside)
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
@@ -190,16 +193,16 @@ function App() {
 
   return (
     <div className="min-h-screen bg-ds-dark p-2 sm:p-4">
-      <div className="fixed top-1 left-1 text-xs text-slate-400 z-50 pointer-events-none">v{APP_VERSION}</div>
-      
+      <div className="fixed bottom-1 left-1 text-xs text-slate-400 z-50 pointer-events-none">v{APP_VERSION}</div>
+
       {/* Settings Button */}
       <div className="fixed top-2 right-2 z-50" ref={settingsRef}>
         <button
           id="settings-button"
           onClick={() => setIsSettingsOpen(!isSettingsOpen)}
           className="bg-ds-gray border border-ds-light-gray text-white p-2 sm:p-3 rounded-lg 
-                   hover:bg-ds-light-gray hover:border-ds-blue transition-all duration-200
-                   focus:outline-none focus:ring-2 focus:ring-ds-blue focus:ring-opacity-50
+                   opacity-60 hover:opacity-100 hover:bg-ds-light-gray hover:border-ds-blue
+                   transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ds-blue focus:ring-opacity-50
                    flex items-center justify-center"
           aria-label="Settings"
           aria-expanded={isSettingsOpen}
@@ -224,8 +227,8 @@ function App() {
 
         {/* Settings Dropdown Menu */}
         {isSettingsOpen && (
-          <div 
-            role="menu" 
+          <div
+            role="menu"
             aria-labelledby="settings-button"
             className="absolute right-0 top-full mt-2 w-48 sm:w-56 bg-ds-gray border border-ds-light-gray rounded-lg shadow-lg py-2 z-50"
           >


### PR DESCRIPTION
Add a settings button with a dropdown menu containing the 'Reset All Materials' button to improve UI organization and mobile experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce92a48c-542b-4a54-abbe-d19854883807">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce92a48c-542b-4a54-abbe-d19854883807">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>